### PR TITLE
Allow concat on multiline

### DIFF
--- a/Symfony3Custom/ruleset.xml
+++ b/Symfony3Custom/ruleset.xml
@@ -96,6 +96,7 @@
     <rule ref="Squiz.Strings.ConcatenationSpacing">
         <properties>
             <property name="spacing" value="1"/>
+            <property name="ignoreNewlines" value="true" />
         </properties>
     </rule>
 


### PR DESCRIPTION
This makes sure that you are allowed to have a concatenated string across multiple lines:
```php
    const VIDEO_TYPES = [
        'YouTube' => "/(?:https?:)?(?:\/\/)?(?:[0-9A-Z-]+\.)?(?:youtu\.be\/|youtube(?:-nocookie)?\.com\S*?" .
            "[^\w\s-])([\w-]{11})(?=[^\w-]|$)(?![?=&+%\w.-]*(?:['\"][^<>]*>|<\/a>))[?=&+%\w.-]*/",
        'Vimeo'   => '/(?:https?:\/\/)?(?:www\.)?(?:player\.)?vimeo\.com\/(?:[a-z]*\/)*([‌​0-9]{6,11})[?]?.*/',
    ];
```