### PR TITLE
Use newer php_codesniffer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "squizlabs/php_codesniffer": "~2.0"
+        "squizlabs/php_codesniffer": "~3.0"
     }
 }


### PR DESCRIPTION
endouble/symfony3-custom-coding-standard is currently preventing us from upgrading squizlabs/php_codesniffer.