### PR TITLE
php_codesniffer version 3 allowed in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "squizlabs/php_codesniffer": "~2.0"
+        "squizlabs/php_codesniffer": "~2.0|~3.0"
     }
 }


### PR DESCRIPTION
squizlabs/php_codesniffer version 3.0 cannot be used with current composer setup.